### PR TITLE
Change to bring in v1.8 of s30 middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "mustache-express": "^1.2.2",
     "node-uuid": "^1.4.7",
     "request": "^2.69.0",
-    "s3o-middleware": "^1.6.0"
+    "s3o-middleware": "^1.8.0"
   },
   "engines": {
     "node": "5.3.0"


### PR DESCRIPTION
Update file to bring in version 1.8 of s30 middleware, which will change s30 timeout to 8 hours.